### PR TITLE
Fix shared-global CAS expected-value in resize_extent

### DIFF
--- a/src/shared_int.c
+++ b/src/shared_int.c
@@ -56,10 +56,6 @@ enum shr_int_constants
 };
 
 
-// static null value for use in CAS
-static void *null = NULL;
-
-
 /*
     convert_to_status -- converts errno value to sh_status_e value
 
@@ -579,7 +575,17 @@ extern view_s resize_extent(
     // update current extent
     extent_s *tail = view.extent;
 
-    if ( CAS( (long*) &tail->next, (long*) &null, (long) next ) ) {
+    /*
+     * Expected value MUST be a per-call stack local: CAS() writes the current
+     * value back into *expected on failure. A shared/global expected variable
+     * gets clobbered when concurrent threads sharing one handle race to grow
+     * the same queue, corrupting subsequent resizes (drives base->current to
+     * NULL -> SEGV). Inter-process producers each have a private handle and
+     * never contend here, which is why this stayed latent. See regression
+     * harness in token_monitor/volume_test3.py.
+     */
+    void *expected_next = NULL;
+    if ( CAS( (long*) &tail->next, (long*) &expected_next, (long) next ) ) {
 
         CAS( (long*) &base->current, (long*) &tail, (long) next );
 


### PR DESCRIPTION
resize_extent used a file-scope `static void *null` as the CAS expected-value when linking a newly mapped extent:

    if ( CAS( (long*) &tail->next, (long*) &null, (long) next ) ) {

CAS() (__atomic_compare_exchange_n) writes *mem back into *expected on failure. When two threads sharing one queue handle race to grow the same queue, the losing thread's failed CAS clobbers the shared `null` global with a live extent pointer. A later resize then compares a genuinely-NULL tail->next against the corrupted global, fails spuriously, and drives base->current to NULL -- the next access dereferences current->array at offset 8 and SEGVs.

This is unreachable for multi-process producers (each process has a private handle and the resize CAS never contends), so it stayed latent in production; it only triggers when multiple threads share one handle, e.g. token_monitor's main + inflight threads both producing to out_q.

Use a per-call stack local for the CAS expected-value so a losing CAS only scribbles on its own stack. Remove the now-unused `null` global.

Validated: token_monitor regression harness went from 6/16 crashes to 0/many; libshr test suite (714 asserts) still passes.